### PR TITLE
Fill null submission result with empty string

### DIFF
--- a/index.js
+++ b/index.js
@@ -159,6 +159,7 @@ class DOMjudgeConverter {
                         break;
                 }
             }
+            if (submission['result'] === null) submission['result'] = "";
         }
 
         // Ignore compile error submissions


### PR DESCRIPTION
Submission result could be null in some circumstances. (i.e. judging runs)
which breaks isJudgedYes on Spotboard (https://github.com/spotboard/spotboard/blob/d9a930c37c8a0bfc205c2111fb2638ba87e88953/webapp/src/js/contest.coffee#L354 ).

Affected Version: Domjudge 7.3.x